### PR TITLE
chore: log output directory

### DIFF
--- a/src/ahlbatross/main.py
+++ b/src/ahlbatross/main.py
@@ -647,6 +647,7 @@ def _process_submodule(output_dir: Path = DEFAULT_OUTPUT_DIR) -> None:
     """
     processes all valid consecutive <formatversion> subdirectories.
     """
+    logger.info("The output dir is %s", output_dir.absolute())
     consecutive_formatversions = determine_consecutive_formatversions()
 
     if not consecutive_formatversions:


### PR DESCRIPTION
because I guess it might not be the one we expect
is `Path("foo/bar")` relative to the cwd?
